### PR TITLE
Update to Python 3 and Ulauncher API 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 ![Extension in action](https://github.com/wallace11/ulauncher-url-shortener/blob/master/demo.png)
 
 ### Requirements
-- Python 2.7.9+
-- python-requests (`pip install requests / pip2 install requests`)
+- Python 3+
+- Ulauncher V5+
+- python-requests (`pip3 install requests`)
 
 ### Changes
+
+- 2019-08-10 Add support for Python 3 and Ulauncher V5
 - 2018-10-11 Change service provider ([is.gd](https://is.gd))
 - 2018-06-03 Add a custom domain option
 - 2018-05-18 First Release

--- a/main.py
+++ b/main.py
@@ -6,7 +6,8 @@ from ulauncher.api.shared.action.RenderResultListAction import RenderResultListA
 from ulauncher.api.shared.action.HideWindowAction import HideWindowAction
 from ulauncher.api.shared.action.CopyToClipboardAction import CopyToClipboardAction
 from requests import get
-from urllib2 import urlopen, URLError
+from urllib.request import urlopen
+from urllib.error import URLError
 from re import match
 
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,5 @@
 {
-    "manifest_version": "2",
-    "api_version": "1",
+    "required_api_version": "^2.0.0",
     "name": "URL Shortener",
     "description": "Shortens your URLs ;)",
     "developer_name": "wallace",

--- a/versions.json
+++ b/versions.json
@@ -1,0 +1,11 @@
+[
+    {
+      "required_api_version": "^1.0.0",
+      "commit": "api-v1"
+    },
+    {
+      "required_api_version": "^2.0.0",
+      "commit": "master"
+    }
+  ]
+  


### PR DESCRIPTION
This PR updates this extension to Python 3 and the new Ulauncher version.

To make it compatible to the old version, before merging this PR, please create a new branch or tag named api-v1.